### PR TITLE
Add support for removing at-rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,5 +17,13 @@ module.exports = postcss.plugin('postcss-exclude-classes', (opts) => {
                 }
             });
         });
+
+        css.walkAtRules((rule) => {
+            opts.blacklist.forEach((item) => {
+                if (item.startsWith('@') && item.substr(1) === rule.name) {
+                    rule.remove();
+                }
+            });
+        });
     };
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-exclude-classes",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "PostCSS plugin to exclude named classes",
   "keywords": [
     "postcss",

--- a/test.js
+++ b/test.js
@@ -32,3 +32,15 @@ test('ensure the class is not removed', t => {
 test('ensure the class is not removed without blacklist', t => {
     return run(t, '.dont-remove-me { }', '.dont-remove-me { }', {});
 });
+
+test('ensure at-rules are removed without blacklist', t => {
+    return run(t, '@at-root { @viewport { width: device-width } }', '', {
+        blacklist: ['@at-root']
+    });
+});
+
+test('ensure at-rules are not removed without blacklist', t => {
+    return run(t, '@media screen { }', '@media screen { }', {
+        blacklist: ['@at-root']
+    });
+});


### PR DESCRIPTION
It would be nice to be able to exclude `@at-rules`, for example, for excluding `@at-root` rules when generating CSS for Accelerated Mobile Pages . This adds support for this.

Includes a version number bump to 0.0.2.
